### PR TITLE
Add missing false-check to the ConfiguredRegularPrice price-model

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
+++ b/app/code/Magento/Catalog/Pricing/Price/ConfiguredRegularPrice.php
@@ -63,7 +63,7 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
 
         return $this;
     }
-    
+
     /**
      * Price value of product with configured options.
      *
@@ -73,7 +73,7 @@ class ConfiguredRegularPrice extends RegularPrice implements ConfiguredPriceInte
     {
         $basePrice = parent::getValue();
 
-        return $this->item
+        return $this->item && $basePrice !== false
             ? $basePrice + $this->configuredOptions->getItemOptionsValue($basePrice, $this->item)
             : $basePrice;
     }


### PR DESCRIPTION
### Original Port
#15129

## Description
`parent::getValue()` can return false while `$this->configuredOptions->getItemOptionsValue` only accepts float. So if the parent method returns false then it fails with the following error:

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
